### PR TITLE
Fixes #247 - Creating local registry will fail on bastion, if Internet access is only possible with proxy

### DIFF
--- a/templates/local-registry.service.j2
+++ b/templates/local-registry.service.j2
@@ -3,6 +3,18 @@ Description=OpenShift Registry for HelperNode
 After=network.target syslog.target
 
 [Service]
+{% if proxy.server != "" and proxy.user == "" %}
+Environment=ftp_proxy="http://{{ proxy.server }}:{{ proxy.port }}"
+Environment=http_proxy="http://{{ proxy.server }}:{{ proxy.port }}"
+Environment=https_proxy="http://{{ proxy.server }}:{{ proxy.port }}"
+Environment=no_proxy="{{ proxy.no_proxy }}"
+{% endif %}
+{% if proxy.server != "" and proxy.user != "" %}
+Environment=ftp_proxy="http://{{ proxy.user }}:{{ proxy.password }}@{{ proxy.server }}:{{ proxy.port }}"
+Environment=http_proxy="http://{{ proxy.user }}:{{ proxy.password }}@{{ proxy.server }}:{{ proxy.port }}"
+Environment=https_proxy="http://{{ proxy.user }}:{{ proxy.password }}@{{ proxy.server }}:{{ proxy.port }}"
+Environment=no_proxy="{{ proxy.no_proxy }}"
+{% endif %}
 Type=simple
 TimeoutStartSec=5m
 ExecStartPre=-/usr/bin/podman rm "local-registry"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,3 +24,4 @@ setup_registry:
   release_name: "ocp-release"
   release_tag: "4.8.2-x86_64"
 machineconfig_path: ../machineconfig
+  


### PR DESCRIPTION
Fixes #247 
I have implemented a fix/feature to support proxy in local-registry.service.j2 so that the components for the mirror registry services can be downloaded/installed even in such environments.
I have tested it with proxy and it worked fine. Unfortunately, I could not test the code without proxy properly (my env requires one :)

It would be great, if someone could test it without proxy. Otherwise, any suggestion for improvement is highly welcome.