### PR TITLE
No domain-search for wildcard domain

### DIFF
--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -8,11 +8,11 @@ max-lease-time 14400;
     option subnet-mask              {{ dhcp.netmask }};
 {% if dhcp.dns is defined and dhcp.dns != "" %}
     option domain-name-servers      {{ dhcp.dns }};
+    option domain-search            "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}";
 {% else %}
     option domain-name-servers      {{ helper.ipaddr }};
 {% endif %}
-    option domain-name              "{{ dns.clusterid }}.{{ dns.domain | lower }}";
-    option domain-search            "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}";
+    option domain-name              "{{ dns.clusterid }}.{{ dns.domain | lower }}";    
 
     subnet {{ dhcp.ipid }} netmask {{ dhcp.netmaskid }} {
     interface {{ networkifacename }};


### PR DESCRIPTION
Code changes for not to use the domain-search when wildcard domain is used. This is to address the issue "https://github.com/ocp-power-automation/ocp4-upi-powervs/issues/228#issue-823055643"