### PR TITLE
change ppc64le nfs provisioner image

### DIFF
--- a/tasks/setup_registry.yaml
+++ b/tasks/setup_registry.yaml
@@ -145,4 +145,4 @@
 
   - name: Mirror NFS image (ppc64le)
     when: setup_registry.autosync_registry and ppc64le
-    shell: "oc image mirror docker.io/ibmcom/nfs-client-provisioner-ppc64le:latest registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner-ppc64le:latest -a ~/.openshift/pull-secret-updated"
+    shell: "oc image mirror gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:ppc64le-linux-v4.0.0 registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated"

--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -17,16 +17,10 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-{% if ansible_architecture == "ppc64le" and setup_registry.deploy %}
-          image: registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner-ppc64le:latest
-{% elif ansible_architecture == "ppc64le" %}
-          image: ibmcom/nfs-client-provisioner-ppc64le:latest
-{% else %}
 {% if setup_registry.deploy and  setup_registry.autosync_registry %}
           image: registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest
 {% else %}
           image: gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:v4.0.0
-{% endif %}
 {% endif %}
           volumeMounts:
             - name: nfs-client-root


### PR DESCRIPTION
Since new nfs provisioner image is now multiarch we should use it instead. The images in ibmcom org which will be deleted from dockerhub.

Signed-off-by: Yussuf Shaikh <yussuf@us.ibm.com>