### PR TITLE
PR support for RHEL 9 (Plow) + ansible-core 2.13.3

### DIFF
--- a/tasks/restart_config.yaml
+++ b/tasks/restart_config.yaml
@@ -12,7 +12,7 @@
     dest: /etc/systemd/system/{{item}}.service.d/restart.conf
 
 - name: restart services
-  service:
+  systemd:
     name: "{{ item }}"
     state: restarted
     daemon_reload: yes

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -8,21 +8,12 @@
     - set_fact:
         networkifacename: "{{ ansible_default_ipv4.interface }}"
 
-- block:
-  - set_fact:
-      critical_services:
-        - httpd
-        - named
-        - haproxy
-
-- block:
-  - set_fact:
-      critical_services: "{{ critical_services }} + [ 'dhcpd' ]"
+- set_fact:
+    critical_services: "['dhcpd', 'httpd', 'named', 'haproxy']"
   when: not staticips
 
-- block:
-  - set_fact:
-      critical_services: "{{ critical_services }} + [ 'keepalived' ]"
+- set_fact:
+    critical_services: "['keepalived', 'httpd', 'named', 'haproxy']"
   when: high_availability is defined
 
 - block:
@@ -130,3 +121,48 @@
         - rpcbind
         - nfs-server
   when: ansible_distribution_major_version >= "8"
+
+- block:
+  - set_fact:
+      packages:
+        - bind
+        - bind-utils
+        - firewalld
+        - haproxy
+        - httpd
+        - vim
+        - bash-completion
+        - python3-libselinux
+        - podman
+        - nfs-utils
+        - grub2-tools
+        - grub2-tools-extra
+  
+  - set_fact:
+      dhcppkgs:
+        - dhcp-server
+        - tftp-server
+
+  - set_fact:
+      syslinuxpkgs:
+        - syslinux
+
+  - set_fact:
+      uefipkgs:
+        - shim-x64
+        - grub2-efi-x64
+
+  # See Fedora Wiki for changes:
+  # https://fedoraproject.org/wiki/Changes/RenameNobodyUser
+  - set_fact:
+      owner: nobody
+      group: nobody
+  
+  - set_fact:
+      services:
+        - named
+        - haproxy
+        - httpd
+        - rpcbind
+        - nfs-server
+  when: ansible_distribution_major_version >= "9"


### PR DESCRIPTION
Read issue #296 and thought I'd share the recent work I had to do to get this working on RHEL 9.

Please note that I installed ansible provided via EPEL which in turn pulled in ansible-core and libraries from their respective RHEL repositories and that is what I used to execute these changes.

~~~
Removing:
 ansible                                                              noarch                                                 5.4.0-3.el9                                                    @epel                                                                             301 M
Removing unused dependencies:
 ansible-core                                                         x86_64                                                 2.13.3-1.el9                                                   @rhel-9-for-x86_64-appstream-rpms                                                  11 M
 python3-cffi                                                         x86_64                                                 1.14.5-5.el9                                                   @rhel-9-for-x86_64-appstream-rpms                                                 1.0 M
 python3-cryptography                                                 x86_64                                                 36.0.1-2.el9                                                   @rhel-9-for-x86_64-appstream-rpms                                                 4.5 M
 python3-packaging                                                    noarch                                                 20.9-5.el9                                                     @rhel-9-for-x86_64-appstream-rpms                                                 248 k
 python3-pycparser                                                    noarch                                                 2.20-6.el9                                                     @rhel-9-for-x86_64-appstream-rpms                                                 745 k
 python3-pyparsing                                                    noarch                                                 2.4.7-9.el9                                                    @rhel-9-for-x86_64-baseos-rpms                                                    635 k
 python3-resolvelib                                                   noarch                                                 0.5.4-5.el9                                                    @rhel-9-for-x86_64-appstream-rpms                                                  66 k
 sshpass                                                              x86_64                                                 1.09-4.el9                                                     @rhel-9-for-x86_64-appstream-rpms                                                  47 k
~~~

Note: I faced an issue attempting to loop through the critical services fact, so I ended up moving it into a list and it just worked without issue.