### PR TITLE
Create critical_services as documented by ansible for use with loop.

### DIFF
--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -17,12 +17,12 @@
 
 - block:
   - set_fact:
-      critical_services: "{{ critical_services }} + [ 'dhcpd' ]"
+      critical_services: "{{ critical_services + [ 'dhcpd' ] }}"
   when: not staticips
 
 - block:
   - set_fact:
-      critical_services: "{{ critical_services }} + [ 'keepalived' ]"
+      critical_services: "{{ critical_services + [ 'keepalived' ] }}"
   when: high_availability is defined
 
 - block:


### PR DESCRIPTION
When using with recent version of ansible-core (>2.12) playbook crashes with the followinf error:

```
module.helpernode.null_resource.config (remote-exec): TASK [Enable restart always for critical services] *****************************
module.helpernode.null_resource.config (remote-exec): fatal: [10.3.98.50]: FAILED! => {"msg": "Invalid data passed to 'loop', it requires a list, got this instead: ['httpd', 'named', 'haproxy'] + [ 'dhcpd' ]. Hint: If you passed a list/dict of just one element, try adding wantlist=True to your lookup invocation or use q/query instead of lookup."}
```

Some variables set furing `set_facts.yaml` need to be set propoerly in order to be interpreted as list and not string.