### PR TITLE
Running local-registry container in privileged mode

### DIFF
--- a/templates/local-registry.service.j2
+++ b/templates/local-registry.service.j2
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/podman run   --name local-registry -p 5000:5000 \
                                 -v /opt/registry/certs:/certs:z \
                                 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
                                 -e REGISTRY_HTTP_TLS_KEY=/certs/domain.pem \
-                                {{ setup_registry.registry_image }}
+                                --privileged {{ setup_registry.registry_image }}
 
 ExecReload=-/usr/bin/podman stop "local-registry"
 ExecReload=-/usr/bin/podman rm "local-registry"


### PR DESCRIPTION
For RHEL 9, selinux prevents access for running local-registry container in unprivileged mode.