### PR TITLE
add internet variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,18 +30,21 @@
     package:
       name: "{{ packages }}"
       state: present
+    when: internet
 
   - name: Install packages for DHCP/PXE install
     package:
       name: "{{ dhcppkgs }}"
       state: present
-    when: not staticips
+    when: 
+      - not staticips
+      - internet 
 
   - name: Install additional package for Intel platforms
     package:
       name: "{{ syslinuxpkgs }}"
       state: present
-    when: not staticips and not ppc64le
+    when: not staticips and not ppc64le and internet 
 
   - name: Remove existing config files
     import_tasks: remove_old_config_files.yaml
@@ -559,7 +562,9 @@
       state: absent
 
   - name: Install and configure helm
-    when: helm_source is defined
+    when: 
+      - helm_source is defined
+      - internet
     block:
     - name: Create helm source directory
       file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -28,3 +28,4 @@ setup_registry:
   registry_user: "admin"
   registry_password: "admin"
 machineconfig_path: ../machineconfig
+internet: true


### PR DESCRIPTION
the variable internet=false tells Ansible to not perform some action that need internet access.
The user will have to be sure that the image deployed has the right packages already installed.

The reason for this is when the bastion has to be deployed in a network that can't connect to internet (disconnected cluster).