### PR TITLE
Change include to include_tasks to avoid breakage from ansible-core 2.16.2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
     when: ssh_gen_key
 
   - name: set setup facts
-    include: set_facts_.yaml
+    import_tasks: set_facts_.yaml
 
   - name: Install needed packages
     package:


### PR DESCRIPTION
With the latest Centos-Stream-8, `ansible-core` the version `2.16.2-1.el8` is installed. The `ocp4-helpernode` fails with this error:

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. 
This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

@Chandan-Abhyankar found a fix, and it's nominal change.

Testing locally, I found this be fine. I'm raising the PR, however credit goes to Chandan.
Chandan also tested this in the automation.