### PR TITLE
OPENSHIFTP-256 : Helper-node ACL changes for allow-recursion and allow-query-cache

### DIFF
--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -28,8 +28,8 @@ options {
 	*/
 	recursion yes;
 {% if secure_named %}
-        allow-recursion { trusted; };
-        allow-query-cache { trusted; };
+	allow-recursion { trusted; };
+	allow-query-cache { trusted; };
 {% endif %}
 
 	/* Fowarders */

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -27,6 +27,10 @@ options {
 	   reduce such attack surface 
 	*/
 	recursion yes;
+{% if secure_named %}
+        allow-recursion { trusted; };
+        allow-query-cache { trusted; };
+{% endif %}
 
 	/* Fowarders */
 	forward only;
@@ -76,3 +80,18 @@ zone "{{ helper.ipaddr.split('.')[2] }}.{{ helper.ipaddr.split('.')[1] }}.{{ hel
 include "/etc/named.rfc1912.zones";
 include "/etc/named.root.key";
 
+{% if secure_named %}
+acl "trusted" {
+{% if bootstrap is defined %}
+   {{ bootstrap.ipaddr }}/32;
+{% endif %}
+{% for m in masters %}
+   {{ m.ipaddr }}/32;
+{% endfor %}
+{% for w in workers %}
+   {{ w.ipaddr }}/32;
+{% endfor %}
+   localhost;
+   localnets;
+};
+{% endif %}

--- a/templates/nfs-exports.j2
+++ b/templates/nfs-exports.j2
@@ -1,11 +1,9 @@
 {% if bootstrap is defined %}
-/data           {{ bootstrap.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
+/export           {{ bootstrap.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
 {% endif %}
 {% for m in masters %}
-/data           {{ m.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
-/data/registry  {{ m.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
+/export           {{ m.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
 {% endfor %}
 {% for w in workers %}
-/data           {{ w.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
-/data/registry  {{ w.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
+/export           {{ w.ipaddr }}(rw,sync,no_wdelay,no_root_squash,insecure)
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,3 +32,4 @@ fips: false
 secure_named: false
 secure_http: false
 secure_nfs: false
+secure_named: false


### PR DESCRIPTION
Code changes to update ocp4-helpernode ACL's in order that accounts for trusted networks.