### PR TITLE
OPENSHIFTP-256 : improve ocp4-helpernode allow-recursion and allow-query-cache

### DIFF
--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -27,6 +27,10 @@ options {
 	   reduce such attack surface 
 	*/
 	recursion yes;
+{% if secure_named %}
+	allow-recursion { trusted; };
+	allow-query-cache { trusted; };
+{% endif %}
 
 	/* Fowarders */
 	forward only;
@@ -76,3 +80,18 @@ zone "{{ helper.ipaddr.split('.')[2] }}.{{ helper.ipaddr.split('.')[1] }}.{{ hel
 include "/etc/named.rfc1912.zones";
 include "/etc/named.root.key";
 
+{% if secure_named %}
+acl "trusted" {
+{% if bootstrap is defined %}
+   {{ bootstrap.ipaddr }}/32;
+{% endif %}
+{% for m in masters %}
+   {{ m.ipaddr }}/32;
+{% endfor %}
+{% for w in workers %}
+   {{ w.ipaddr }}/32;
+{% endfor %}
+   localhost;
+   localnets;
+};
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,3 +32,4 @@ fips: false
 secure_named: false
 secure_http: false
 secure_nfs: false
+secure_named: false


### PR DESCRIPTION
This is related to https://jsw.ibm.com/browse/OPENSHIFTP-256
ocp4-helpernode code changes for allow-recursion and allow-query-cache.
