### PR TITLE
fix: gcr.io being shutdown in March 2025

### DIFF
--- a/tasks/setup_registry.yaml
+++ b/tasks/setup_registry.yaml
@@ -145,4 +145,4 @@
 
   - name: Mirror NFS image (ppc64le)
     when: setup_registry.autosync_registry and ppc64le
-    shell: "oc image mirror gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner:ppc64le-linux-v4.0.0 registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated"
+    shell: "oc image mirror registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2 registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated"


### PR DESCRIPTION
redirects to using registry.k8s.io

ref: https://groups.google.com/a/kubernetes.io/g/dev/c/U5jTmvhoYLg