### PR TITLE
fix: secure_named listed twice in vars/main.yml

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,4 +32,3 @@ fips: false
 secure_named: false
 secure_http: false
 secure_nfs: false
-secure_named: false


### PR DESCRIPTION
fix: secure_named listed twice in vars/main.yml

Hey @Prajyot-Parab Can you review? Thanks, Paul