### PR TITLE
fix: spelling within the setup registry task

### DIFF
--- a/tasks/setup_registry.yaml
+++ b/tasks/setup_registry.yaml
@@ -96,7 +96,7 @@
   - internal
   - public
 
-- name: Restarting regitry services
+- name: Restarting registry services
   service:
     name: "{{ item }}"
     state: restarted


### PR DESCRIPTION
fix: spelling within the setup registry task